### PR TITLE
Clean up instructions, add Cross-signing link

### DIFF
--- a/www/index.html.template
+++ b/www/index.html.template
@@ -123,9 +123,9 @@
 
   <h3>Step 2: Enable Cross Signing</h3>
   <ol>
-    <li>Go to Settings --> Security & Privacy --> Cross Signing.</li>
+    <li>Go to Settings --> Security & Privacy --> Cross-signing.</li>
     <li>If you see a green checkmark with <code>Cross-signing is ready for use</code>, then you are good to go.</li>
-    <li>If you see <code>Cross Signing has not been set up</code>, then click <code>Set Up</code>, then follow the
+    <li>If you see <code>Cross-signing has not been set up</code>, then click <code>Set Up</code>, then follow the
       instructions to complete setup.</li>
     <li>Alternatively, if you see <code>Cross-signing is ready but keys are not backed up</code>, follow the backup instructions in Step 4</li>
   </ol>
@@ -134,8 +134,9 @@
     and not impostors. To make this as simple as possible, Matrix offers something called Cross Signing, which allows
     users to verify each other, and then for each user to verify their own various devices. The alternative is that
     every user would need to verify every
-    device of everyone they interact with, which is simply annoying. You can read more about Cross Signing <a href=""
-      target="_blank">here</a>.</p>
+    device of everyone they interact with, which is simply annoying. You can read more about Cross Signing 
+    <a href="https://element.io/blog/e2e-encryption-by-default-cross-signing-is-here/" target="_blank">here</a>.
+  </p>
 
   <br />
   <hr style="border: 1px dashed #bbb;" />

--- a/www/index.html.template
+++ b/www/index.html.template
@@ -123,10 +123,11 @@
 
   <h3>Step 2: Enable Cross Signing</h3>
   <ol>
-    <li>Go to Settings --> Security and Privacy --> Cross Signing.</li>
+    <li>Go to Settings --> Security & Privacy --> Cross Signing.</li>
     <li>If you see a green checkmark with <code>Cross-signing is ready for use</code>, then you are good to go.</li>
     <li>If you see <code>Cross Signing has not been set up</code>, then click <code>Set Up</code>, then follow the
       instructions to complete setup.</li>
+    <li>Alternatively, if you see <code>Cross-signing is ready but keys are not backed up</code>, follow the backup instructions in Step 4</li>
   </ol>
   <p>Explanation: The Matrix protocol uses advanced cryptography to ensure that you are, in fact, communicating with the
     people you think you are,
@@ -142,7 +143,7 @@
 
   <h3>Step 3: Joining a Room</h3>
   <ol>
-    <li>On the main dashboard, select <code>Join a Public Room</code>.</li>
+    <li>On the main dashboard, select <code>Explore Public Rooms</code>.</li>
     <li>In the search field, paste in the alias of the room you want to join. Room aliases start with #. For example,
       Start9's Tor Party room
       is <a href="https://matrix.to/#/#tor-party:matrix.privacy34kn4ez3y3nijweec6w4g54i3g54sdv7r5mr6soma3w4begyd.onion"
@@ -177,8 +178,8 @@
             ensure the recovery of messages up until that point in time.</p>
           <ol>
             <li>
-              In your Element app, go to Settings --> Security and Privacy --> Encryption/Cryptography --> "Export
-              E2E Room Keys"
+              In your Element app, go to Settings --> Security & Privacy --> Cryptography --> "Export
+              E2E room keys"
             </li>
             <li>
               Optionally enter a passphrase to protect the backup and save the file somewhere safe
@@ -196,7 +197,7 @@
             and is the recommended way of doing key backup</p>
           <ol>
             <li>
-              In your Element app, go to Settings --> Security and Privacy --> Encryption/SecureBackup --> "Setup".
+              In your Element app, go to Settings --> Security & Privacy --> Secure Backup --> "Set up".
             </li>
             <li>
               You will be prompted to select either <code>Generate a Security Key</code> or


### PR DESCRIPTION
A few small changes to the instructions to match the UI. 

Also added a [link for Cross-signing](https://element.io/blog/e2e-encryption-by-default-cross-signing-is-here/) as it was empty. Not sure what the intended link was though. Maybe @dr-bonez knows as he added the link. :)

## Screenshots

### Security & Privacy -- all set up

![Screenshot from 2022-05-27 11-33-53](https://user-images.githubusercontent.com/7598058/170611624-99b9f9fa-08a0-4b92-abfe-5ef6eae81f95.png)

### Cross-signing enabled, but not backed up

![Screenshot from 2022-05-27 11-09-11](https://user-images.githubusercontent.com/7598058/170613741-3092ba64-64b5-45a2-8733-43f89ded2307.png)

### Not backed up

![Screenshot from 2022-05-27 11-12-55](https://user-images.githubusercontent.com/7598058/170614271-68001885-8dfc-4e51-9680-84bc60589210.png)

### Explore Public Rooms

![Screenshot from 2022-05-27 10-18-14](https://user-images.githubusercontent.com/7598058/170614112-148bd861-5845-4c02-b26a-3c9573849b56.png)

