### PR TITLE
Created a github action to build synapse package. 

### DIFF
--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -1,0 +1,61 @@
+# This is a basic workflow that is manually triggered
+
+name: Build Service
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "greet"
+  BuildPackage:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+        
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      
+    - name: Set up Docker Buildx        
+      uses: docker/setup-buildx-action@v1     
+           
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        
+        
+    - name: Install packages
+      run: |
+           sudo snap install yq deno
+           sudo apt-get install -y build-essential openssl libssl-dev libc6-dev clang libclang-dev ca-certificates
+      
+      #check out service package for synapse
+    - name: Checkout tools repo
+      uses: actions/checkout@v3
+           
+    - name: install package manager stuff
+      run: |
+           cd ~/ && git clone https://github.com/Start9Labs/embassy-os.git; #TODO probably should make this an action or a variable of some sort.
+           cd embassy-os;
+           git submodule update --init --recursive
+           cd backend;
+           ./install-sdk.sh;
+
+
+    - name: build the service package!
+      run: |
+           git submodule update --init --recursive
+           embassy-sdk init
+           make
+           mv synapse*s9pk ~/ #move this to home directory for easy reference in the upload step
+
+    - name: upload service package
+      uses: actions/upload-artifact@v3
+      with:
+        name: synapse
+        path: ~/*.s9pk


### PR DESCRIPTION
cleaner remake of https://github.com/Start9Labs/synapse-wrapper/pull/38 

This will allow you to use github actions to build a package without having to set up a build environment on your local machine. In theory, you should be able to use this framework for other services if you just switch out synapse for whatever.

One limitation is that I can't run this in https://github.com/nektos/act locally, which would had been super useful. The rust action at the beginning breaks. Not too sure if it's a bug with my local machine, or with `act` itself. I opened up an issue with them, https://github.com/nektos/act/issues/1295 