### PR TITLE
added in cache functionality to build job to speed things up

### DIFF
--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -28,7 +28,16 @@ jobs:
         toolchain: stable
         override: true
         
-        
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-compat-${{ hashFiles('**/system-images/compat/Cargo.lock') }}
+                
     - name: Install packages
       run: |
            sudo snap install yq deno
@@ -39,6 +48,8 @@ jobs:
       uses: actions/checkout@v3
            
     - name: install package manager stuff
+      id: packageManager
+      if: steps.packageManager.outputs.cache-hit != 'true'
       run: |
            cd ~/ && git clone https://github.com/Start9Labs/embassy-os.git; #TODO probably should make this an action or a variable of some sort.
            cd embassy-os;

--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -36,7 +36,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-compat-${{ hashFiles('**/system-images/compat/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-compat-${{ git ls-remote https://github.com/Start9Labs/embassy-os HEAD | awk '{ print $1}' }}
                 
     - name: Install packages
       run: |

--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -34,6 +34,7 @@ jobs:
       
         
     - uses: actions/cache@v3
+      id: packageCache
       with:
         path: |
           ~/.cargo/bin/
@@ -54,7 +55,7 @@ jobs:
            
     - name: install package manager stuff
       id: packageManager
-      if: steps.packageManager.outputs.cache-hit != 'true'
+      if: steps.packageCache.outputs.cache-hit != 'true'
       run: |
            cd ~/ && git clone https://github.com/Start9Labs/embassy-os.git; #TODO probably should make this an action or a variable of some sort.
            cd embassy-os;

--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -42,7 +42,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-compat-${{ env.EMBASSYHASH }}
+        key: ${{ runner.os }}-synapse-${{ env.EMBASSYHASH }}
                 
     - name: Install packages
       run: |

--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -28,6 +28,11 @@ jobs:
         toolchain: stable
         override: true
         
+        
+    - name: Get EmbassyOS Hash
+      run:  echo "EMBASSYHASH=$(git ls-remote https://github.com/Start9Labs/embassy-os HEAD | awk '{ print $1}')" >> $GITHUB_ENV
+      
+        
     - uses: actions/cache@v3
       with:
         path: |
@@ -36,7 +41,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-compat-${{ git ls-remote https://github.com/Start9Labs/embassy-os HEAD | awk '{ print $1}' }}
+        key: ${{ runner.os }}-cargo-compat-${{ env.EMBASSYHASH }}
                 
     - name: Install packages
       run: |


### PR DESCRIPTION
We don't need to be rebuilding the embassy SDK every build. This addition checks the git hash of embassyOS master, and if it's different, it will recreate a cache. Otherwise, use the cache for a build.