### PR TITLE
made regex less restrictive

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -38,7 +38,7 @@ EOT
 echo "    server_name ${TOR_ADDRESS};" >> /etc/nginx/conf.d/default.conf
 cat >> /etc/nginx/conf.d/default.conf <<"EOT"
     root /var/www;
-    location ~* ^(\/_matrix|\/_synapse\/client) {
+    location ~* ^(\/_matrix|\/_synapse) {
         proxy_pass http://127.0.0.1:8008;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
There are API endpoints that are not reverse proxied because their routes are _synapse/admin and not _synapse/client. For example: https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html 

This PR modifies the regex so that the _synapse/admin are also accessible