### PR TITLE
chore: bump Synapse to 1.154.0; 1.153.0:0 → 1.154.0:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     synapse: {
       source: {
-        dockerTag: 'ghcr.io/element-hq/synapse:v1.153.0',
+        dockerTag: 'ghcr.io/element-hq/synapse:v1.154.0',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -2,13 +2,13 @@ import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
 import { sdk } from '../sdk'
 
 export const current = VersionInfo.of({
-  version: '1.153.0:0',
+  version: '1.154.0:0',
   releaseNotes: {
-    en_US: 'Bumps Synapse → 1.153.0.',
-    es_ES: 'Actualiza Synapse → 1.153.0.',
-    de_DE: 'Aktualisiert Synapse → 1.153.0.',
-    pl_PL: 'Aktualizuje Synapse → 1.153.0.',
-    fr_FR: 'Met à jour Synapse → 1.153.0.',
+    en_US: 'Bumps Synapse → 1.154.0.',
+    es_ES: 'Actualiza Synapse → 1.154.0.',
+    de_DE: 'Aktualisiert Synapse → 1.154.0.',
+    pl_PL: 'Aktualizuje Synapse → 1.154.0.',
+    fr_FR: 'Met à jour Synapse → 1.154.0.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps Synapse to **1.154.0** (from 1.153.0).

- `dockerTag` → `ghcr.io/element-hq/synapse:v1.154.0`
- `startos/versions/current.ts` → `1.154.0:0` with updated release notes (all locales). The existing `create-admin-user` task-clear migration carries forward on the current node (`other: []`).
- `npm update` refreshed a transitive lockfile dependency (`@nodable/entities` 2.1.0 → 2.1.1).

No SDK bump — `@start9labs/start-sdk` already pins the latest (1.5.3). No Ketesa bump — `SYNAPSE_ADMIN_VERSION` already at the latest (v1.2.1).

### Upstream changelog (1.154.0)

Minor release: bugfixes (refresh-token cache invalidation, `/sync` edge cases, `M_BAD_JSON` regression, policy-server signature merge), one opt-in experimental feature (MSC4452 preview URL capability, disabled by default), and internal Rust-port work. No breaking changes affecting the package.

## Test plan

- [x] `npm run check` (typecheck) green
- [ ] `make` / s9pk pack verified in review