### PR TITLE
chore: bump Synapse to 1.155.0; 1.154.0:0 → 1.155.0:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -105,6 +105,18 @@
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/deep-equality-data-structures": {
       "version": "2.0.0",
@@ -231,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -247,16 +259,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     synapse: {
       source: {
-        dockerTag: 'ghcr.io/element-hq/synapse:v1.154.0',
+        dockerTag: 'ghcr.io/element-hq/synapse:v1.155.0',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -2,13 +2,48 @@ import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
 import { sdk } from '../sdk'
 
 export const current = VersionInfo.of({
-  version: '1.154.0:0',
+  version: '1.155.0:0',
   releaseNotes: {
-    en_US: 'Bumps Synapse → 1.154.0.',
-    es_ES: 'Actualiza Synapse → 1.154.0.',
-    de_DE: 'Aktualisiert Synapse → 1.154.0.',
-    pl_PL: 'Aktualizuje Synapse → 1.154.0.',
-    fr_FR: 'Met à jour Synapse → 1.154.0.',
+    en_US: `Updated Synapse to 1.155.0.
+
+- Bugfix: limit to-device EDU size to keep outgoing federation from stalling.
+- Bugfix: work around a failure when joining restricted rooms that need a remote join.
+- Bugfix: Sliding Sync now returns updated room subscriptions immediately.
+- Note: this is the last Synapse release to ship Debian 12 Bookworm packages (does not affect this StartOS package).
+
+Full notes: https://github.com/element-hq/synapse/releases/tag/v1.155.0`,
+    es_ES: `Synapse actualizado a 1.155.0.
+
+- Corrección: limita el tamaño de los EDU to-device para evitar que se detenga la federación saliente.
+- Corrección: soluciona un fallo al unirse a salas restringidas que requieren una unión remota.
+- Corrección: Sliding Sync ahora devuelve de inmediato las suscripciones de sala actualizadas.
+- Nota: esta es la última versión de Synapse que incluye paquetes de Debian 12 Bookworm (no afecta a este paquete de StartOS).
+
+Notas completas: https://github.com/element-hq/synapse/releases/tag/v1.155.0`,
+    de_DE: `Synapse auf 1.155.0 aktualisiert.
+
+- Fehlerbehebung: begrenzt die Größe von to-device-EDUs, damit die ausgehende Föderation nicht ins Stocken gerät.
+- Fehlerbehebung: umgeht einen Fehler beim Betreten eingeschränkter Räume, die einen Remote-Beitritt erfordern.
+- Fehlerbehebung: Sliding Sync liefert geänderte Raum-Abonnements jetzt sofort.
+- Hinweis: Dies ist die letzte Synapse-Version mit Debian-12-Bookworm-Paketen (betrifft dieses StartOS-Paket nicht).
+
+Vollständige Hinweise: https://github.com/element-hq/synapse/releases/tag/v1.155.0`,
+    pl_PL: `Zaktualizowano Synapse do 1.155.0.
+
+- Poprawka: ogranicza rozmiar EDU to-device, aby nie blokować wychodzącej federacji.
+- Poprawka: obchodzi błąd przy dołączaniu do ograniczonych pokoi wymagających zdalnego dołączenia.
+- Poprawka: Sliding Sync natychmiast zwraca zaktualizowane subskrypcje pokoi.
+- Uwaga: to ostatnie wydanie Synapse z pakietami Debian 12 Bookworm (nie dotyczy tego pakietu StartOS).
+
+Pełne informacje: https://github.com/element-hq/synapse/releases/tag/v1.155.0`,
+    fr_FR: `Synapse mis à jour vers 1.155.0.
+
+- Correctif : limite la taille des EDU to-device pour éviter que la fédération sortante ne se bloque.
+- Correctif : contourne un échec lors de la jonction de salons restreints nécessitant une jonction distante.
+- Correctif : Sliding Sync renvoie désormais immédiatement les abonnements de salon mis à jour.
+- Note : il s'agit de la dernière version de Synapse à fournir des paquets Debian 12 Bookworm (sans incidence sur ce paquet StartOS).
+
+Notes complètes : https://github.com/element-hq/synapse/releases/tag/v1.155.0`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps Synapse **1.154.0 → 1.155.0** (minor; bugfixes only). Ketesa (admin dashboard) stays at `v1.2.1` — no upstream movement. `@start9labs/start-sdk` already pins the latest (`1.5.3`); `npm update` refreshed transitive deps in `package-lock.json`.

### Changes
- `dockerTag` → `ghcr.io/element-hq/synapse:v1.155.0` in `startos/manifest/index.ts`.
- `startos/versions/current.ts`: `version` → `1.155.0:0`, release notes updated in all locales. Edited in place (no new migration); the existing idempotent `clearTask` migration is carried forward, matching the prior bump.

### Upstream highlights (1.155.0)
- Limit to-device EDU size to keep outgoing federation from stalling.
- Work around a failure when joining restricted rooms requiring a remote join.
- Sliding Sync returns updated room subscriptions immediately.
- Last Synapse release to ship Debian 12 Bookworm packages (does not affect this StartOS package).

Full notes: https://github.com/element-hq/synapse/releases/tag/v1.155.0

## Test plan
- `npm run check` (tsc --noEmit) — green.
- `make` / s9pk build verification deferred to PR review per monitor-cycle policy.