### PR TITLE
chore: bump start-sdk to 2.0.7 (1.156.0:3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,46 @@
     "": {
       "name": "synapse-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.6"
+        "@start9labs/start-sdk": "2.0.7"
       },
       "devDependencies": {
         "@types/node": "^22.19.0",
         "@vercel/ncc": "^0.38.4",
         "prettier": "^3.7.4",
         "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
+      "license": "ISC"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodable/entities": {
@@ -28,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-2.0.6.tgz",
-      "integrity": "sha512-0aTCnCvDZWp3UGqmyB8xQL1A0mWYlIwbTdHyQQkha/aOAzFpTIC6MIwkDCLnXLpoFqhF6btbBPp9hIMKwsRBOw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-2.0.7.tgz",
+      "integrity": "sha512-lJuZto0vfD/2fPubzwavuStAdlnQQo8AmYFvBBhENY4WbXAXJ64b5zuXwrkmJ8wZObUngno5LYZWWr7yOlYLxQ==",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",
@@ -301,36 +334,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@start9labs/start-sdk/node_modules/@iarna/toml": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core": {
       "inBundle": true,
       "license": "MIT",
@@ -346,6 +349,36 @@
         "zod-deep-partial": "^1.4.4"
       }
     },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@iarna/toml": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/deep-equality-data-structures": {
       "version": "2.0.0",
       "inBundle": true,
@@ -354,12 +387,108 @@
         "object-hash": "^3.0.0"
       }
     },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/mime": {
+      "version": "4.1.0",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/object-hash": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/tr46": {
+      "version": "0.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/yaml": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod": {
       "version": "4.4.3",
       "inBundle": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod-deep-partial": {
+      "version": "1.4.4",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "zod": "^4.1.13"
       }
     },
     "node_modules/@start9labs/start-sdk/node_modules/@types/estree": {
@@ -1130,15 +1259,6 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/@start9labs/start-sdk/node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
     "node_modules/@start9labs/start-sdk/node_modules/json-buffer": {
       "version": "3.0.1",
       "inBundle": true,
@@ -1179,20 +1299,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/@start9labs/start-sdk/node_modules/mime": {
-      "version": "4.1.0",
-      "funding": [
-        "https://github.com/sponsors/broofa"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@start9labs/start-sdk/node_modules/ms": {
       "version": "2.1.3",
       "inBundle": true,
@@ -1202,33 +1308,6 @@
       "version": "1.4.0",
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/object-hash": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/@start9labs/start-sdk/node_modules/optionator": {
       "version": "0.9.4",
@@ -1370,11 +1449,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/@start9labs/start-sdk/node_modules/tr46": {
-      "version": "0.0.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/@start9labs/start-sdk/node_modules/ts-api-utils": {
       "version": "2.5.0",
       "inBundle": true,
@@ -1427,25 +1501,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/@start9labs/start-sdk/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/@start9labs/start-sdk/node_modules/which": {
       "version": "2.0.2",
       "inBundle": true,
@@ -1468,20 +1523,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@start9labs/start-sdk/node_modules/yaml": {
-      "version": "2.9.0",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/@start9labs/start-sdk/node_modules/yocto-queue": {
       "version": "0.1.0",
       "inBundle": true,
@@ -1491,14 +1532,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/zod-deep-partial": {
-      "version": "1.4.4",
-      "inBundle": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "zod": "^4.1.13"
       }
     },
     "node_modules/@types/ini": {
@@ -1594,6 +1627,51 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/mime": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
@@ -1649,6 +1727,12 @@
         "anynum": "^1.0.1"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -1669,6 +1753,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/xml-naming": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -1684,6 +1790,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -1691,6 +1812,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-deep-partial": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/zod-deep-partial/-/zod-deep-partial-1.4.4.tgz",
+      "integrity": "sha512-aWkPl7hVStgE01WzbbSxCgX4O+sSpgt8JOjvFUtMTF75VgL6MhWQbiZi+AWGN85SfSTtI9gsOtL1vInoqfDVaA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "zod": "^4.1.13"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "2.0.6"
+    "@start9labs/start-sdk": "2.0.7"
   },
   "devDependencies": {
     "@types/node": "^22.19.0",

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,7 +1,7 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '1.156.0:2',
+  version: '1.156.0:3',
   releaseNotes: {
     en_US: `Updated Synapse to 1.156.0.
 


### PR DESCRIPTION
Bumps `@start9labs/start-sdk` 2.0.6 → 2.0.7 and cuts `1.156.0:2` → `1.156.0:3`.

No upstream change; internal SDK patch bump only. Lockfile reconverged; `npm run check` green.

Part of the fleet-wide start-sdk 2.0.7 refresh.