### PR TITLE
chore: bump Synapse to 1.157.2; bump Ketesa to 1.4.0; 1.156.0:5 → 1.157.2:0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ ARCHES := x86 arm
 # overrides to s9pk.mk must precede the include statement
 include node_modules/@start9labs/start-sdk/s9pk.mk
 
-SYNAPSE_ADMIN_VERSION = v1.3.0
-SYNAPSE_ADMIN_CHECKSUM = ad241735fe683ff25aa6a46c791024e5df4aedd8e89814e0ee9649f9280801c3
+SYNAPSE_ADMIN_VERSION = v1.4.0
+SYNAPSE_ADMIN_CHECKSUM = 34351c13293e66ed3c024598ce48bbc7b347784b9e618b0ceaf1cb42a7a730b7
 
 # Ensure synapse-admin is built as part of 'ingredients' (which the s9pk
 # recipe runs before packing). A prerequisite-only pattern rule like

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 | PostgreSQL image | `postgres` Alpine (database sidecar)                    |
 | Architectures    | x86_64, aarch64                                         |
 
-Synapse runs behind an Nginx reverse proxy. Nginx handles client requests on port 80, proxies Matrix API traffic to Synapse on port 8008, and serves the [Synapse Admin](https://github.com/etkecc/synapse-admin) dashboard on port 8080.
+Synapse runs behind an Nginx reverse proxy. Nginx handles client requests on port 80, proxies Matrix API traffic to Synapse on port 8008, and serves the [Ketesa](https://github.com/etkecc/ketesa) admin dashboard on port 8080.
 
 ---
 

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     synapse: {
       source: {
-        dockerTag: 'ghcr.io/element-hq/synapse:v1.156.0',
+        dockerTag: 'ghcr.io/element-hq/synapse:v1.157.2',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,33 +1,63 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '1.156.0:5',
+  version: '1.157.2:0',
   releaseNotes: {
-    en_US: `Settings now take effect on their own — no more restarting Synapse by hand.
+    en_US: `Updates Synapse to 1.157.2 and the Ketesa admin dashboard to 1.4.0.
 
-- Fixes "Set Admin Password" requiring a manual restart before the new password worked.
-- Moves SMTP out of "Config" into its own "Configure SMTP" action, which applies immediately. Turning SMTP off now actually clears the credentials, which it previously did not.
-- Removes the "Create Bot User" action. Create user accounts from the Users tab of the Admin Dashboard instead.`,
-    es_ES: `Los ajustes ahora se aplican solos: ya no hay que reiniciar Synapse a mano.
+Synapse 1.157.2 is a security release fixing eleven advisories, six of them high severity. Upgrading is recommended, especially if your homeserver participates in open federation or has untrusted local users. Also included, from 1.157.0 and 1.157.1:
 
-- Corrige que «Set Admin Password» requiriera un reinicio manual para que la nueva contraseña funcionara.
-- Traslada la configuración SMTP de «Config» a su propia acción «Configure SMTP», que se aplica de inmediato. Desactivar SMTP ahora sí borra las credenciales, algo que antes no ocurría.
-- Elimina la acción «Create Bot User». Cree las cuentas de usuario desde la pestaña «Users» del panel de administración.`,
-    de_DE: `Einstellungen werden jetzt von selbst wirksam – kein manueller Neustart von Synapse mehr nötig.
+- Fixes bridges and other appservices no longer receiving ephemeral events, including the to-device messages that encryption relies on. This was a regression in 1.156.0.
+- Fixes reactivating a deactivated and erased user not restoring their profile, which broke login, name changes and invitations.
+- Fixes repeated deadlocks in Sliding Sync.
 
-- Behebt, dass „Set Admin Password“ einen manuellen Neustart erforderte, bevor das neue Passwort funktionierte.
-- Verschiebt SMTP aus „Config“ in eine eigene Aktion „Configure SMTP“, die sofort wirksam wird. Das Deaktivieren von SMTP löscht die Zugangsdaten nun tatsächlich, was zuvor nicht der Fall war.
-- Entfernt die Aktion „Create Bot User“. Legen Sie Benutzerkonten stattdessen im Tab „Users“ des Admin-Dashboards an.`,
-    pl_PL: `Ustawienia zaczynają teraz obowiązywać samoczynnie — bez ręcznego restartu Synapse.
+Ketesa 1.4.0 stops the login screen rewriting your server URL when \`wellKnownDiscovery\` is set to false, moves the user list filters behind a Filter button, and corrects the admin flag and user type shown for Matrix Authentication Service accounts.
 
-- Naprawia „Set Admin Password”, które wymagało ręcznego restartu, zanim nowe hasło zaczęło działać.
-- Przenosi SMTP z „Config” do osobnej akcji „Configure SMTP”, która działa natychmiast. Wyłączenie SMTP faktycznie usuwa teraz dane logowania, czego wcześniej nie robiło.
-- Usuwa akcję „Create Bot User”. Konta użytkowników twórz w zakładce „Users” panelu administracyjnego.`,
-    fr_FR: `Les réglages prennent désormais effet d'eux-mêmes — plus besoin de redémarrer Synapse à la main.
+Full release notes: https://github.com/element-hq/synapse/releases/tag/v1.157.2 and https://github.com/etkecc/ketesa/releases/tag/v1.4.0`,
+    es_ES: `Actualiza Synapse a 1.157.2 y el panel de administración Ketesa a 1.4.0.
 
-- Corrige « Set Admin Password », qui nécessitait un redémarrage manuel avant que le nouveau mot de passe ne fonctionne.
-- Déplace la configuration SMTP de « Config » vers une action « Configure SMTP » dédiée, appliquée immédiatement. Désactiver SMTP efface maintenant réellement les identifiants, ce qui n'était pas le cas auparavant.
-- Supprime l'action « Create Bot User ». Créez les comptes utilisateur depuis l'onglet « Users » du tableau de bord d'administration.`,
+Synapse 1.157.2 es una versión de seguridad que corrige once avisos, seis de ellos de gravedad alta. Se recomienda actualizar, sobre todo si su servidor participa en la federación abierta o tiene usuarios locales no confiables. También se incluye, de 1.157.0 y 1.157.1:
+
+- Corrige que los puentes y otros appservices dejaran de recibir eventos efímeros, incluidos los mensajes «to-device» de los que depende el cifrado. Era una regresión de 1.156.0.
+- Corrige que reactivar a un usuario desactivado y borrado no restaurara su perfil, lo que rompía el inicio de sesión, los cambios de nombre y las invitaciones.
+- Corrige bloqueos repetidos en Sliding Sync.
+
+Ketesa 1.4.0 evita que la pantalla de inicio de sesión reescriba la URL de su servidor cuando \`wellKnownDiscovery\` está en false, traslada los filtros de la lista de usuarios a un botón «Filter» y corrige el indicador de administrador y el tipo de usuario mostrados para las cuentas de Matrix Authentication Service.
+
+Notas de versión completas: https://github.com/element-hq/synapse/releases/tag/v1.157.2 y https://github.com/etkecc/ketesa/releases/tag/v1.4.0`,
+    de_DE: `Aktualisiert Synapse auf 1.157.2 und das Ketesa-Admin-Dashboard auf 1.4.0.
+
+Synapse 1.157.2 ist eine Sicherheitsversion, die elf Sicherheitshinweise behebt, sechs davon mit hohem Schweregrad. Ein Update wird empfohlen, insbesondere wenn Ihr Homeserver an der offenen Föderation teilnimmt oder nicht vertrauenswürdige lokale Benutzer hat. Ebenfalls enthalten, aus 1.157.0 und 1.157.1:
+
+- Behebt, dass Bridges und andere Appservices keine ephemeren Ereignisse mehr erhielten, einschließlich der To-Device-Nachrichten, auf die die Verschlüsselung angewiesen ist. Dies war eine Regression in 1.156.0.
+- Behebt, dass beim Reaktivieren eines deaktivierten und gelöschten Benutzers dessen Profil nicht wiederhergestellt wurde, wodurch Anmeldung, Namensänderungen und Einladungen nicht mehr funktionierten.
+- Behebt wiederholte Deadlocks in Sliding Sync.
+
+Ketesa 1.4.0 verhindert, dass die Anmeldeseite Ihre Server-URL umschreibt, wenn \`wellKnownDiscovery\` auf false steht, verlagert die Filter der Benutzerliste hinter eine Schaltfläche „Filter“ und korrigiert die Anzeige von Administratorkennzeichen und Benutzertyp für Konten des Matrix Authentication Service.
+
+Vollständige Versionshinweise: https://github.com/element-hq/synapse/releases/tag/v1.157.2 und https://github.com/etkecc/ketesa/releases/tag/v1.4.0`,
+    pl_PL: `Aktualizuje Synapse do 1.157.2, a panel administracyjny Ketesa do 1.4.0.
+
+Synapse 1.157.2 to wydanie bezpieczeństwa naprawiające jedenaście zgłoszeń, w tym sześć o wysokiej istotności. Zalecana jest aktualizacja, zwłaszcza jeśli Twój serwer uczestniczy w otwartej federacji lub ma niezaufanych użytkowników lokalnych. Zawiera także zmiany z 1.157.0 i 1.157.1:
+
+- Naprawia sytuację, w której mostki i inne appservices przestawały otrzymywać zdarzenia efemeryczne, w tym wiadomości to-device, na których opiera się szyfrowanie. Była to regresja z 1.156.0.
+- Naprawia brak przywracania profilu po reaktywacji dezaktywowanego i wymazanego użytkownika, co psuło logowanie, zmiany nazwy i zaproszenia.
+- Naprawia powtarzające się zakleszczenia w Sliding Sync.
+
+Ketesa 1.4.0 nie przepisuje już adresu URL serwera na ekranie logowania, gdy \`wellKnownDiscovery\` ma wartość false, przenosi filtry listy użytkowników pod przycisk „Filter” oraz poprawia wyświetlanie oznaczenia administratora i typu użytkownika dla kont Matrix Authentication Service.
+
+Pełne informacje o wydaniu: https://github.com/element-hq/synapse/releases/tag/v1.157.2 oraz https://github.com/etkecc/ketesa/releases/tag/v1.4.0`,
+    fr_FR: `Met à jour Synapse vers 1.157.2 et le tableau de bord d'administration Ketesa vers 1.4.0.
+
+Synapse 1.157.2 est une version de sécurité qui corrige onze bulletins, dont six de gravité élevée. La mise à jour est recommandée, en particulier si votre serveur participe à la fédération ouverte ou compte des utilisateurs locaux non fiables. Sont également inclus, depuis 1.157.0 et 1.157.1 :
+
+- Corrige le fait que les passerelles et autres appservices ne recevaient plus les événements éphémères, y compris les messages « to-device » dont dépend le chiffrement. Il s'agissait d'une régression de 1.156.0.
+- Corrige la réactivation d'un utilisateur désactivé et effacé qui ne restaurait pas son profil, ce qui cassait la connexion, les changements de nom et les invitations.
+- Corrige des blocages répétés dans Sliding Sync.
+
+Ketesa 1.4.0 empêche l'écran de connexion de réécrire l'URL de votre serveur lorsque \`wellKnownDiscovery\` vaut false, place les filtres de la liste des utilisateurs derrière un bouton « Filter » et corrige l'indicateur d'administrateur et le type d'utilisateur affichés pour les comptes Matrix Authentication Service.
+
+Notes de version complètes : https://github.com/element-hq/synapse/releases/tag/v1.157.2 et https://github.com/etkecc/ketesa/releases/tag/v1.4.0`,
   },
   migrations: {},
 })


### PR DESCRIPTION
Bumps both of this package's upstreams: Synapse `1.156.0` → `1.157.2`, and the Ketesa admin dashboard `v1.3.0` → `v1.4.0`. StartOS version `1.156.0:5` → `1.157.2:0`.

## Synapse 1.157.2

**This is a security release** — eleven advisories, six of them high severity. Upstream recommends upgrading promptly, particularly for homeservers on open federation or with untrusted local users.

Rolled up from `1.157.0`/`1.157.1` along the way, the fixes most likely to matter here:

- Application services that opted into ephemeral events via the legacy `de.sorunome.msc2409.push_ephemeral` flag stopped receiving them — including the to-device messages encryption depends on. A regression introduced in `1.156.0`, i.e. the version this package currently ships. Relevant to bridge dependents that register through `ensureAppserviceRegistration`.
- Reactivating a deactivated-and-erased user did not restore their profile, breaking login, name changes and invitations.
- Repeated deadlocks in Sliding Sync when inserting lazy members.

`1.157.0` also removes experimental MSC3861 auth delegation. **Not applicable to this package** — grepping `startos/` for `msc3861`/`experimental_features` returns nothing, so the generated `homeserver.yaml` never enabled it. No migration needed.

Upstream notes: [v1.157.0](https://github.com/element-hq/synapse/releases/tag/v1.157.0) · [v1.157.1](https://github.com/element-hq/synapse/releases/tag/v1.157.1) · [v1.157.2](https://github.com/element-hq/synapse/releases/tag/v1.157.2)

## Ketesa v1.4.0

- The login screen now honours `wellKnownDiscovery: false` instead of rewriting the server URL you typed.
- User list filters moved behind a Filter button rather than being welded into the toolbar.
- MAS fixes: admin flag and `user_type` now resolve correctly.

The rest of the release is etke.cc-hosted billing UI and dependency bumps, neither of which reaches this package. [Upstream notes](https://github.com/etkecc/ketesa/releases/tag/v1.4.0).

## Artifact verification

- `ghcr.io/element-hq/synapse:v1.157.2` — `docker manifest inspect` resolves.
- `ketesa.tar.gz` for `v1.4.0` — downloads (HTTP 200), SHA-256 `34351c13293e66ed3c024598ce48bbc7b347784b9e618b0ceaf1cb42a7a730b7`, recorded in `SYNAPSE_ADMIN_CHECKSUM`. Tarball layout is unchanged (single `ketesa/` top-level dir), so the Makefile's `--strip-components=1` still applies.
- Registry's newest published version is `1.156.0:5`, so `1.157.2:0` is free.

## Other changes

- `README.md`: the admin dashboard link pointed at `etkecc/synapse-admin`, the pre-rename repo. Repointed to `etkecc/ketesa` alongside the pin bump.

No SDK bump — `package.json` already pins `2.0.9`, which is current on npm. No git dependencies in this package, so nothing to re-resolve; `package-lock.json` is untouched.

## Test plan

- [x] `npm run check` green.
- [ ] `make` builds `synapse_x86_64.s9pk` (deferred to review per the monitor cycle).
