### PR TITLE
chore: bump Synapse to 1.158.0; 1.157.2:0 → 1.158.0:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     synapse: {
       source: {
-        dockerTag: 'ghcr.io/element-hq/synapse:v1.157.2',
+        dockerTag: 'ghcr.io/element-hq/synapse:v1.158.0',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,63 +1,48 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '1.157.2:0',
+  version: '1.158.0:0',
   releaseNotes: {
-    en_US: `Updates Synapse to 1.157.2 and the Ketesa admin dashboard to 1.4.0.
+    en_US: `Updates Synapse to 1.158.0.
 
-Synapse 1.157.2 is a security release fixing eleven advisories, six of them high severity. Upgrading is recommended, especially if your homeserver participates in open federation or has untrusted local users. Also included, from 1.157.0 and 1.157.1:
+- New rooms are now created with room version 11 by default, in line with Matrix v1.14.
+- Thumbnails can now be animated, opted into per request with the \`animated\` query parameter.
+- Fixes intermittent failures when creating rooms or sending third-party (3pid) invitations over federation in version 12 rooms.
+- Fixes the homeserver not shutting down cleanly.
 
-- Fixes bridges and other appservices no longer receiving ephemeral events, including the to-device messages that encryption relies on. This was a regression in 1.156.0.
-- Fixes reactivating a deactivated and erased user not restoring their profile, which broke login, name changes and invitations.
-- Fixes repeated deadlocks in Sliding Sync.
+Full release notes: https://github.com/element-hq/synapse/blob/release-v1.158/CHANGES.md`,
+    es_ES: `Actualiza Synapse a 1.158.0.
 
-Ketesa 1.4.0 stops the login screen rewriting your server URL when \`wellKnownDiscovery\` is set to false, moves the user list filters behind a Filter button, and corrects the admin flag and user type shown for Matrix Authentication Service accounts.
+- Las salas nuevas se crean ahora con la versión de sala 11 de forma predeterminada, en línea con Matrix v1.14.
+- Las miniaturas pueden ser animadas, activándose en cada petición con el parámetro de consulta \`animated\`.
+- Corrige fallos intermitentes al crear salas o al enviar invitaciones de terceros (3pid) por federación en salas de versión 12.
+- Corrige que el homeserver no se apagara limpiamente.
 
-Full release notes: https://github.com/element-hq/synapse/releases/tag/v1.157.2 and https://github.com/etkecc/ketesa/releases/tag/v1.4.0`,
-    es_ES: `Actualiza Synapse a 1.157.2 y el panel de administración Ketesa a 1.4.0.
+Notas de versión completas: https://github.com/element-hq/synapse/blob/release-v1.158/CHANGES.md`,
+    de_DE: `Aktualisiert Synapse auf 1.158.0.
 
-Synapse 1.157.2 es una versión de seguridad que corrige once avisos, seis de ellos de gravedad alta. Se recomienda actualizar, sobre todo si su servidor participa en la federación abierta o tiene usuarios locales no confiables. También se incluye, de 1.157.0 y 1.157.1:
+- Neue Räume werden jetzt standardmäßig mit Raumversion 11 erstellt, passend zu Matrix v1.14.
+- Vorschaubilder können nun animiert sein; dies wird pro Anfrage über den Abfrageparameter \`animated\` aktiviert.
+- Behebt sporadische Fehler beim Erstellen von Räumen und beim Versenden von Drittanbieter-Einladungen (3pid) über die Föderation in Räumen der Version 12.
+- Behebt, dass der Homeserver nicht sauber heruntergefahren wurde.
 
-- Corrige que los puentes y otros appservices dejaran de recibir eventos efímeros, incluidos los mensajes «to-device» de los que depende el cifrado. Era una regresión de 1.156.0.
-- Corrige que reactivar a un usuario desactivado y borrado no restaurara su perfil, lo que rompía el inicio de sesión, los cambios de nombre y las invitaciones.
-- Corrige bloqueos repetidos en Sliding Sync.
+Vollständige Versionshinweise: https://github.com/element-hq/synapse/blob/release-v1.158/CHANGES.md`,
+    pl_PL: `Aktualizuje Synapse do 1.158.0.
 
-Ketesa 1.4.0 evita que la pantalla de inicio de sesión reescriba la URL de su servidor cuando \`wellKnownDiscovery\` está en false, traslada los filtros de la lista de usuarios a un botón «Filter» y corrige el indicador de administrador y el tipo de usuario mostrados para las cuentas de Matrix Authentication Service.
+- Nowe pokoje są domyślnie tworzone w wersji 11, zgodnie z Matrix v1.14.
+- Miniatury mogą być animowane — włącza się to dla pojedynczego żądania parametrem zapytania \`animated\`.
+- Naprawia sporadyczne błędy przy tworzeniu pokoi oraz przy wysyłaniu zaproszeń third-party (3pid) przez federację w pokojach w wersji 12.
+- Naprawia brak czystego zamykania serwera.
 
-Notas de versión completas: https://github.com/element-hq/synapse/releases/tag/v1.157.2 y https://github.com/etkecc/ketesa/releases/tag/v1.4.0`,
-    de_DE: `Aktualisiert Synapse auf 1.157.2 und das Ketesa-Admin-Dashboard auf 1.4.0.
+Pełne informacje o wydaniu: https://github.com/element-hq/synapse/blob/release-v1.158/CHANGES.md`,
+    fr_FR: `Met à jour Synapse vers 1.158.0.
 
-Synapse 1.157.2 ist eine Sicherheitsversion, die elf Sicherheitshinweise behebt, sechs davon mit hohem Schweregrad. Ein Update wird empfohlen, insbesondere wenn Ihr Homeserver an der offenen Föderation teilnimmt oder nicht vertrauenswürdige lokale Benutzer hat. Ebenfalls enthalten, aus 1.157.0 und 1.157.1:
+- Les nouveaux salons sont désormais créés en version de salon 11 par défaut, conformément à Matrix v1.14.
+- Les vignettes peuvent être animées, à activer requête par requête via le paramètre \`animated\`.
+- Corrige des échecs intermittents lors de la création de salons et de l'envoi d'invitations tierces (3pid) via la fédération dans les salons de version 12.
+- Corrige l'arrêt non propre du homeserver.
 
-- Behebt, dass Bridges und andere Appservices keine ephemeren Ereignisse mehr erhielten, einschließlich der To-Device-Nachrichten, auf die die Verschlüsselung angewiesen ist. Dies war eine Regression in 1.156.0.
-- Behebt, dass beim Reaktivieren eines deaktivierten und gelöschten Benutzers dessen Profil nicht wiederhergestellt wurde, wodurch Anmeldung, Namensänderungen und Einladungen nicht mehr funktionierten.
-- Behebt wiederholte Deadlocks in Sliding Sync.
-
-Ketesa 1.4.0 verhindert, dass die Anmeldeseite Ihre Server-URL umschreibt, wenn \`wellKnownDiscovery\` auf false steht, verlagert die Filter der Benutzerliste hinter eine Schaltfläche „Filter“ und korrigiert die Anzeige von Administratorkennzeichen und Benutzertyp für Konten des Matrix Authentication Service.
-
-Vollständige Versionshinweise: https://github.com/element-hq/synapse/releases/tag/v1.157.2 und https://github.com/etkecc/ketesa/releases/tag/v1.4.0`,
-    pl_PL: `Aktualizuje Synapse do 1.157.2, a panel administracyjny Ketesa do 1.4.0.
-
-Synapse 1.157.2 to wydanie bezpieczeństwa naprawiające jedenaście zgłoszeń, w tym sześć o wysokiej istotności. Zalecana jest aktualizacja, zwłaszcza jeśli Twój serwer uczestniczy w otwartej federacji lub ma niezaufanych użytkowników lokalnych. Zawiera także zmiany z 1.157.0 i 1.157.1:
-
-- Naprawia sytuację, w której mostki i inne appservices przestawały otrzymywać zdarzenia efemeryczne, w tym wiadomości to-device, na których opiera się szyfrowanie. Była to regresja z 1.156.0.
-- Naprawia brak przywracania profilu po reaktywacji dezaktywowanego i wymazanego użytkownika, co psuło logowanie, zmiany nazwy i zaproszenia.
-- Naprawia powtarzające się zakleszczenia w Sliding Sync.
-
-Ketesa 1.4.0 nie przepisuje już adresu URL serwera na ekranie logowania, gdy \`wellKnownDiscovery\` ma wartość false, przenosi filtry listy użytkowników pod przycisk „Filter” oraz poprawia wyświetlanie oznaczenia administratora i typu użytkownika dla kont Matrix Authentication Service.
-
-Pełne informacje o wydaniu: https://github.com/element-hq/synapse/releases/tag/v1.157.2 oraz https://github.com/etkecc/ketesa/releases/tag/v1.4.0`,
-    fr_FR: `Met à jour Synapse vers 1.157.2 et le tableau de bord d'administration Ketesa vers 1.4.0.
-
-Synapse 1.157.2 est une version de sécurité qui corrige onze bulletins, dont six de gravité élevée. La mise à jour est recommandée, en particulier si votre serveur participe à la fédération ouverte ou compte des utilisateurs locaux non fiables. Sont également inclus, depuis 1.157.0 et 1.157.1 :
-
-- Corrige le fait que les passerelles et autres appservices ne recevaient plus les événements éphémères, y compris les messages « to-device » dont dépend le chiffrement. Il s'agissait d'une régression de 1.156.0.
-- Corrige la réactivation d'un utilisateur désactivé et effacé qui ne restaurait pas son profil, ce qui cassait la connexion, les changements de nom et les invitations.
-- Corrige des blocages répétés dans Sliding Sync.
-
-Ketesa 1.4.0 empêche l'écran de connexion de réécrire l'URL de votre serveur lorsque \`wellKnownDiscovery\` vaut false, place les filtres de la liste des utilisateurs derrière un bouton « Filter » et corrige l'indicateur d'administrateur et le type d'utilisateur affichés pour les comptes Matrix Authentication Service.
-
-Notes de version complètes : https://github.com/element-hq/synapse/releases/tag/v1.157.2 et https://github.com/etkecc/ketesa/releases/tag/v1.4.0`,
+Notes de version complètes : https://github.com/element-hq/synapse/blob/release-v1.158/CHANGES.md`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps Synapse from 1.157.2 to 1.158.0 and releases as `1.158.0:0`.

- `startos/manifest/index.ts`: `ghcr.io/element-hq/synapse:v1.157.2` → `v1.158.0`. The tag resolves on ghcr.io with both `linux/amd64` and `linux/arm64` manifests.
- `startos/versions/current.ts`: version `1.157.2:0` → `1.158.0:0`, release notes rewritten for this release in all five locales.

Ketesa is unchanged — `gh release view -R etkecc/ketesa` still reports `v1.4.0`, which the `Makefile` already pins, so `SYNAPSE_ADMIN_VERSION`/`SYNAPSE_ADMIN_CHECKSUM` are untouched. `@start9labs/start-sdk` is already at 2.0.9, the latest on npm. No `*-startos` git dependencies, so nothing to re-resolve; `package-lock.json` is unchanged.

## Upstream highlights (1.158.0, incl. 1.158.0rc1)

- Default room version for new rooms moves to **11** (MSC4239, Matrix v1.14).
- Media thumbnailer gains animation support, opt-in per request via the `animated` query parameter (off by default).
- New Module API hook `register_federation_callbacks(...)` for federation event delivery.
- Fixes intermittent failures for third-party (3pid) invites over federation and for `/createRoom` (colliding room IDs) in version 12 rooms.
- Fixes server key cache invalidations being silently dropped on workers, and `HomeServer.shutdown()` not shutting down cleanly.
- Deprecation is packaging-only upstream (Ubuntu 25.10 build targets removed) and does not affect this package.

Full changelog: <https://github.com/element-hq/synapse/blob/release-v1.158/CHANGES.md>

No migration is needed: the upstream change carries no on-disk state change for existing installs, and the room-version default only applies to newly created rooms.

## Test plan

- `npm run check` — green.
- Registry check: latest published is `1.157.2:0`, so `1.158.0:0` is free.
- `make` / install verification left to review, per the monitor cycle.
